### PR TITLE
Add GaugeRelative to support Telegraf statsd implementation

### DIFF
--- a/statsd.go
+++ b/statsd.go
@@ -100,6 +100,14 @@ func (c *Client) Gauge(bucket string, value interface{}) {
 	c.conn.gauge(c.prefix, bucket, value, c.tags)
 }
 
+// GaugeRelative records an relative value for the given bucket.
+func (c *Client) GaugeRelative(bucket string, value interface{}) {
+	if c.skip() {
+		return
+	}
+	c.conn.gaugeRelative(c.prefix, bucket, value, c.tags)
+}
+
 // Timing sends a timing value to a bucket.
 func (c *Client) Timing(bucket string, value interface{}) {
 	if c.skip() {


### PR DESCRIPTION
Telegraf doesn't support support negative counters, requiring relative gauge values instead. This adds the new method GaugeRelative to allow for this.