### PR TITLE
Update client to not require a successful ping

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -46,18 +46,6 @@ func newConn(conf connConfig, muted bool) (*conn, error) {
 	if err != nil {
 		return c, err
 	}
-	// When using UDP do a quick check to see if something is listening on the
-	// given port to return an error as soon as possible.
-	if c.network[:3] == "udp" {
-		for i := 0; i < 2; i++ {
-			_, err = c.w.Write(nil)
-			if err != nil {
-				_ = c.w.Close()
-				c.w = nil
-				return c, err
-			}
-		}
-	}
 
 	// To prevent a buffer overflow add some capacity to the buffer to allow for
 	// an additional metric.


### PR DESCRIPTION
Please refer to https://github.com/gdiazlo/statsd as a solution to this issue in the original repo https://github.com/alexcesaro/statsd/issues/6.

This will add the functionality needed while keeping the additional changes that are currently present in this fork.

It is useful to have this change as the metrics within a service *shouldn't* stop a service from operating. Currently, it works as is but as soon as `.Clone` is called on the client, it crashes due to a nil conn (caused by this check).