### PR TITLE
Multiplay paths patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 statsd is a simple and efficient [Statsd](https://github.com/etsy/statsd)
 client.
 
+This is a fork of a [dead statsd client project](https://github.com/alexcesaro/statsd) with various impprovements.
+
 See the [benchmark](https://github.com/alexcesaro/statsdbench) for a comparison
 with other Go StatsD clients.
 
@@ -27,7 +29,7 @@ https://godoc.org/gopkg.in/alexcesaro/statsd.v2
 
 ## Download
 
-    go get gopkg.in/alexcesaro/statsd.v2
+    go get github.com/multiplay/statsd
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # statsd
-[![Build Status](https://travis-ci.org/alexcesaro/statsd.svg?branch=v2)](https://travis-ci.org/alexcesaro/statsd) [![Code Coverage](http://gocover.io/_badge/gopkg.in/alexcesaro/statsd.v2)](http://gocover.io/gopkg.in/alexcesaro/statsd.v2) [![Documentation](https://godoc.org/gopkg.in/alexcesaro/statsd.v2?status.svg)](https://godoc.org/gopkg.in/alexcesaro/statsd.v2)
 
 ## Introduction
 
@@ -8,34 +7,17 @@ client.
 
 This is a fork of a [dead statsd client project](https://github.com/alexcesaro/statsd) with various impprovements.
 
-See the [benchmark](https://github.com/alexcesaro/statsdbench) for a comparison
-with other Go StatsD clients.
-
 ## Features
 
-- Supports all StatsD metrics: counter, gauge, timing and set
+- Supports all StatsD metrics: counter, gauge (absolute and relative), timing and set
 - Supports InfluxDB and Datadog tags
 - Fast and GC-friendly: all functions for sending metrics do not allocate
 - Efficient: metrics are buffered by default
 - Simple and clean API
-- 100% test coverage
-- Versioned API using gopkg.in
-
-
-## Documentation
-
-https://godoc.org/gopkg.in/alexcesaro/statsd.v2
-
 
 ## Download
 
     go get github.com/multiplay/statsd
-
-
-## Example
-
-See the [examples in the documentation](https://godoc.org/gopkg.in/alexcesaro/statsd.v2#example-package).
-
 
 ## License
 
@@ -47,6 +29,4 @@ See the [examples in the documentation](https://godoc.org/gopkg.in/alexcesaro/st
 Do you have any question the documentation does not answer? Is there a use case
 that you feel is common and is not well-addressed by the current API?
 
-If so you are more than welcome to ask questions in the
-[thread on golang-nuts](https://groups.google.com/d/topic/golang-nuts/Tz6t4_iLgnw/discussion)
-or open an issue or send a pull-request here on Github.
+If so you are more than welcome to ask questions or open an issue or send a pull-request here on Github.

--- a/examples_test.go
+++ b/examples_test.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"time"
 
-	"gopkg.in/alexcesaro/statsd.v2"
+	"github.com/multiplay/statsd"
 )
 
 var (


### PR DESCRIPTION
The README and test file should refer to the multiplay fork of the statsd client.

On updating of the import to the test file, it was noticed that the previous PR, that the New() function should no longer return a muted client on `UDP no response`.